### PR TITLE
Removing environment variable check and fixing silent install paths

### DIFF
--- a/winevents/WixUI_HK.wxs
+++ b/winevents/WixUI_HK.wxs
@@ -27,14 +27,14 @@
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg_HK">NOT Installed</Publish>
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
       <Publish Dialog="LicenseAgreementDlg_HK" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
-      <Publish Dialog="LicenseAgreementDlg_HK" Control="Next" Event="NewDialog" Value="ConfigurationDlg">LicenseAccepted = "1" AND NOT EXTERNAL_CONFIGCFG_PATH AND NOT EXISTING_CONFIGCFG_PATH AND LEGACY_UPGRADE = 0</Publish>
-      <Publish Dialog="LicenseAgreementDlg_HK" Control="Next" Event="NewDialog" Value="InstallDirDlg">LicenseAccepted = "1" AND (EXTERNAL_CONFIGCFG_PATH OR EXISTING_CONFIGCFG_PATH OR LEGACY_UPGRADE = 1)</Publish>
+      <Publish Dialog="LicenseAgreementDlg_HK" Control="Next" Event="NewDialog" Value="ConfigurationDlg">LicenseAccepted = "1" AND CONFIGFILE = 0 AND NOT EXISTING_CONFIGCFG_PATH AND LEGACY_UPGRADE = 0</Publish>
+      <Publish Dialog="LicenseAgreementDlg_HK" Control="Next" Event="NewDialog" Value="InstallDirDlg">LicenseAccepted = "1" AND (NOT CONFIGFILE = 0 OR EXISTING_CONFIGCFG_PATH OR LEGACY_UPGRADE = 1)</Publish>
 
       <Publish Dialog="ConfigurationDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg" Order="6">CONFIG_INGEST_SECRET_VALID = "1" AND CONFIG_CLEARTEXT_BACKEND_TARGET_VALID = "1"</Publish>
       <Publish Dialog="ConfigurationDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg_HK">1</Publish>
 
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg_HK">EXTERNAL_CONFIGCFG_PATH OR EXISTING_CONFIGCFG_PATH OR LEGACY_UPGRADE = 1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="ConfigurationDlg">NOT EXTERNAL_CONFIGCFG_PATH AND NOT EXISTING_CONFIGCFG_PATH AND LEGACY_UPGRADE = 0</Publish>
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg_HK">NOT CONFIGFILE = 0 OR EXISTING_CONFIGCFG_PATH OR LEGACY_UPGRADE = 1</Publish>
+      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="ConfigurationDlg">CONFIGFILE = 0 AND NOT EXISTING_CONFIGCFG_PATH AND LEGACY_UPGRADE = 0</Publish>
       <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
       <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
       <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>

--- a/winevents/product.wxs
+++ b/winevents/product.wxs
@@ -50,10 +50,8 @@
         </Directory>
       </Directory>
     </Directory>
-    <!-- Environment variables -->
-    <Property Id="EXTERNAL_CONFIGCFG_PATH" Secure="yes" Value="0" />
-    <SetProperty Id="EXTERNAL_CONFIGCFG_PATH" Value="[%CONFIGFILE]" After="LaunchConditions" Sequence="first" />
     <!-- Configuration properties -->
+    <Property Id="CONFIGFILE" Secure="yes" Value="0" />
     <Property Id="PURGE" Secure="yes" Value="0" />
     <Property Id="CONFIG_INGEST_SECRET" Secure="yes" Value="IngestSecrets" />
     <Property Id="CONFIG_CLEARTEXT_BACKEND_TARGET" Secure="yes" Value="127.0.1.1:4023" />
@@ -72,7 +70,7 @@
         </DirectorySearch>
       </DirectorySearch>
     </Property>
-    <SetProperty Id="CopyConfig" Value="&quot;[SystemFolder]cmd.exe&quot; /c echo f | xcopy &quot;[CONFIGFILE]&quot; &quot;[INSTALLDIR]config.cfg&quot; /Y /Q /R" After="CostFinalize" />
+    <SetProperty Id="CopyConfig" Value="&quot;[SystemFolder]cmd.exe&quot; /c echo f | xcopy &quot;[CONFIGFILE]&quot; &quot;[CONFIGDIR]config.cfg&quot; /Y /Q /R" After="CostFinalize" />
     <CustomAction Id="CopyConfig" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="no" />
     <SetProperty Id="PurgeConfig" Value="&quot;[SystemFolder]cmd.exe&quot; /c del &quot;[CONFIGDIR]&quot; * /Q" After="CostFinalize" />
     <CustomAction Id="PurgeConfig" BinaryKey="WixCA" DllEntry="WixQuietExec" Execute="deferred" Return="check" Impersonate="no" />
@@ -82,7 +80,6 @@
     <!-- Secret should be last since it can potentially include separator (for other values it's illegal) -->
     <CustomAction Property="GenerateConfigCfg" Id="GenerateConfigCfgValues" Value="[CONFIGDIR]|[CONFIG_LOG_LEVEL]|[CONFIG_CLEARTEXT_BACKEND_TARGET]|[CONFIG_INGEST_SECRET]" />
 
-    <!-- <Binary Id="Exclam.ico" SourceFile="Exclam.ico" /> -->
     <Binary Id="customActions.vbs" SourceFile="customActions.vbs" />
     <Property Id="UninstallQuestion_Message" Value="!(loc.UninstallQuestion_Message)" />
     <Property Id="UninstallQuestion_Title" Value="!(loc.UninstallQuestion_Title)" />
@@ -93,8 +90,8 @@
     <InstallExecuteSequence>
       <Custom Action="GenerateConfigCfgValues" After="InstallFiles" />
       <Custom Action="GenerateConfigCfg" After="GenerateConfigCfgValues">NOT Installed AND NOT REMOVE AND LEGACY_UPGRADE = 0 AND NOT EXISTING_CONFIGCFG_PATH</Custom>
-      <Custom Action="CopyConfig" After="GenerateConfigCfg">NOT Installed AND NOT REMOVE AND LEGACY_UPGRADE = 0 AND EXTERNAL_CONFIGCFG_PATH</Custom>
-      <Custom Action='QueryPurgeProgramData' Before='FindRelatedProducts'>NOT UPGRADINGPRODUCTCODE AND REMOVE AND PURGE = 0</Custom>
+      <Custom Action="CopyConfig" After="GenerateConfigCfg">NOT Installed AND NOT REMOVE AND NOT CONFIGFILE = 0</Custom>
+      <Custom Action='QueryPurgeProgramData' Before='FindRelatedProducts'>NOT UPGRADINGPRODUCTCODE AND REMOVE AND PURGE = 0 AND NOT UILevel=2</Custom>
       <Custom Action="PurgeConfig" After="DeleteServices">REMOVE AND PURGE = 1</Custom>
     </InstallExecuteSequence>
     <Feature Id="DefaultFeature" Level="1">


### PR DESCRIPTION
## Changes summary

* Removed environment variable `CONFIG`
* Fixed copy of legacy `config.cfg` to proper location
* Fixed Purge dialog box visibility when installer is running in silent mode